### PR TITLE
Issue with abssolute path for filename when updating a file - fixed

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -319,8 +319,10 @@ class Confluence(AtlassianRestAPI):
                 'X-Atlassian-Token': 'nocheck',
                 'Accept': 'application/json'}
             path = 'rest/api/content/{page_id}/child/attachment'.format(page_id=page_id)
+            # get base name of the file to get the attachment from confluence.
+            file_base_name = os.path.basename(filename)
             # Check if there is already a file with the same name
-            attachments = self.get(path=path, headers=headers, params={'filename': filename})
+            attachments = self.get(path=path, headers=headers, params={'filename': file_base_name})
             if attachments['size']:
                 path = path + '/' + attachments['results'][0]['id'] + '/data'
             with open(filename, 'rb') as infile:


### PR DESCRIPTION
@gonchik,

Hi, I had a fix to the confluence python API for file upload. 

Basically, the file upload does not work if I pass in an absolute path. The code tries to find the filename using the absolute path, cannot find it and then errors when uploading citing a "file already exists error"

The fix is fairly simple, but am unable to create a pull request to the atlassian repo. I see that you are able to contribute. Can you please review and merge?

Thanks.